### PR TITLE
Split logic and make code a module

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,4 @@ repos:
       rev: 'v0.0.263'
       hooks:
         - id: ruff
+          args: [--fix, --exit-non-zero-on-fix, --show-fixes]

--- a/src/global_entry_appointment_notifier/__main__.py
+++ b/src/global_entry_appointment_notifier/__main__.py
@@ -7,10 +7,10 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Iterator, Iterable
 
-from api import GlobalEntryApi
-from logger import setup_logger
-from translators import parse_datetime
-from common_types import Slot
+from global_entry_appointment_notifier.api import GlobalEntryApi
+from global_entry_appointment_notifier.logger import setup_logger
+from global_entry_appointment_notifier.translators import parse_datetime
+from global_entry_appointment_notifier.common_types import Slot
 
 
 setup_logger(os.environ.get("LOGLEVEL", "ERROR").upper())

--- a/src/global_entry_appointment_notifier/api.py
+++ b/src/global_entry_appointment_notifier/api.py
@@ -2,8 +2,8 @@ import logging
 
 from typing import Iterable
 
-from translators import transform_available_slots
-from common_types import ApiAvailableSlot, Slot
+from global_entry_appointment_notifier.translators import transform_available_slots
+from global_entry_appointment_notifier.common_types import ApiAvailableSlot, Slot
 
 import requests
 

--- a/src/global_entry_appointment_notifier/api.py
+++ b/src/global_entry_appointment_notifier/api.py
@@ -1,0 +1,36 @@
+import logging
+
+from typing import Iterable
+
+from translators import transform_available_slots
+from common_types import ApiAvailableSlot, Slot
+
+import requests
+
+
+BASE_URL = "https://ttp.cbp.dhs.gov/schedulerapi/slot-availability"
+
+
+class GlobalEntryApi:
+    session: requests.Session
+
+    def __init__(self) -> None:
+        self.session = requests.Session()
+
+    def get_location_response(self, location: str) -> requests.Response:
+        response = self.session.get(BASE_URL, params={"locationId": location})
+        response.raise_for_status()
+        return response
+
+    def get_appointment_slots(self, location_id: str) -> Iterable[Slot]:
+        try:
+            response = self.get_location_response(location=location_id)
+        except requests.HTTPError:
+            logging.exception("Something went really wrong! We keep going though")
+            raise
+        else:
+            logging.debug("Response status from API: %s", response.status_code)
+
+        data = response.json()
+        api_available_slots: list[ApiAvailableSlot] = data.get("availableSlots")
+        return transform_available_slots(api_available_slots)

--- a/src/global_entry_appointment_notifier/common_types.py
+++ b/src/global_entry_appointment_notifier/common_types.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+from typing_extensions import NamedTuple, TypedDict
+
+
+ApiAvailableSlot = TypedDict(
+    "ApiAvailableSlot",
+    {
+        # The ID of the location where the interview is available at
+        "locationId": int,
+        # Start time of the appointment (2023-12-19T10:30)
+        "startTimestamp": str,
+        # End time of the appointment (2023-12-19T10:45)
+        "endTimestamp": str,
+        # ???
+        "active": bool,
+        # Duration of the appointment. Seems to be in minutes
+        "duration": int,
+        # ???
+        "remoteInd": bool,
+    },
+)
+
+Slot = NamedTuple(
+    "Slot",
+    [
+        ("location_id", int),
+        ("start_timestamp", datetime),
+        ("end_timestamp", datetime),
+        ("active", bool),
+        ("duration", int),
+        ("remote_ind", bool),
+    ],
+)

--- a/src/global_entry_appointment_notifier/translators.py
+++ b/src/global_entry_appointment_notifier/translators.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+from typing import Iterable, Iterator
+
+from common_types import ApiAvailableSlot, Slot
+
+
+def transform_available_slots(available_slots: Iterable[ApiAvailableSlot]) -> Iterator[Slot]:
+    for slot in available_slots:
+        yield Slot(
+            location_id=slot["locationId"],
+            start_timestamp=parse_datetime(slot["startTimestamp"]),
+            end_timestamp=parse_datetime(slot["endTimestamp"]),
+            active=slot["active"],
+            duration=slot["duration"],
+            remote_ind=slot["remoteInd"],
+        )
+
+
+def parse_datetime(datetime_string: str) -> datetime:
+    return datetime.strptime(datetime_string, "%Y-%m-%dT%H:%M")

--- a/src/global_entry_appointment_notifier/translators.py
+++ b/src/global_entry_appointment_notifier/translators.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Iterable, Iterator
 
-from common_types import ApiAvailableSlot, Slot
+from global_entry_appointment_notifier.common_types import ApiAvailableSlot, Slot
 
 
 def transform_available_slots(available_slots: Iterable[ApiAvailableSlot]) -> Iterator[Slot]:


### PR DESCRIPTION
This not only organizes the code a bit nicely, also allows to call `python3 -m global_entry_appointment_notifier --locations ...`